### PR TITLE
feat: Add VO Password with minimum length validation

### DIFF
--- a/src/main/java/br/com/codenoir/domus/application/vo/Password.java
+++ b/src/main/java/br/com/codenoir/domus/application/vo/Password.java
@@ -1,0 +1,47 @@
+package br.com.codenoir.domus.application.vo;
+
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+public class Password {
+
+    @NotBlank(message = "Password cannot blank")
+    @NotNull(message = "Password cannot null")
+    @Min(value = 8, message = "Password must have at least 8 characters")
+    private String value;
+
+    public Password(String value) {
+        this.value = value;
+    }
+
+    public static Password encrypted(String encryptedValue) {
+        return new Password(encryptedValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(this == o) return true;
+        if(!(o instanceof Password password)) return false;
+        return Objects.equals(value, password.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "******";
+    }
+
+}


### PR DESCRIPTION
# Descrição

Criação do Value Object Password com validações e suporte a senha criptografada

Este PR adiciona o VO Password, que encapsula a lógica de representação de senhas no sistema. Inclui validações de segurança como não ser nula, não ser em branco e ter no mínimo 8 caracteres. A senha é representada como ****** ao ser convertida para string, e o método encrypted permite instanciar uma senha já criptografada.

# Tipo de Mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

# Checklist

- [x] Código segue o padrão de estilo do projeto.
- [ ] Foram adicionados testes para a nova funcionalidade ou correção.
- [ ] A documentação foi atualizada (se necessário).
- [ ] O SonarQube não reporta novos problemas críticos.
- [x] A aplicação foi testada localmente e está funcionando como esperado.
