### PR TITLE
feat: Add Company creation and search via GraphQL

### DIFF
--- a/src/main/java/br/com/codenoir/domus/application/dto/CompanyRequestDTO.java
+++ b/src/main/java/br/com/codenoir/domus/application/dto/CompanyRequestDTO.java
@@ -1,38 +1,29 @@
-package br.com.codenoir.domus.application.entity;
+package br.com.codenoir.domus.application.dto;
 
 import br.com.codenoir.domus.application.vo.CNPJ;
 import br.com.codenoir.domus.application.vo.EmailAddress;
 import br.com.codenoir.domus.application.vo.Password;
 import br.com.codenoir.domus.application.vo.Username;
-import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
-import java.util.UUID;
-
-@Entity(name = "tb_company")
 @Data
-public class CompanyEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+public class CompanyRequestDTO {
 
     @NotBlank(message = "Name cannot blank")
-    @NotNull(message = "Name cannot null")
     private String name;
 
-    @Embedded
+    @Valid
     private Username username;
 
-    @Embedded
+    @Valid
     private Password password;
 
-    @Embedded
+    @Valid
     private CNPJ cnpj;
 
-    @Embedded
+    @Valid
     private EmailAddress emailAddress;
 
 }

--- a/src/main/java/br/com/codenoir/domus/application/entity/UserEntity.java
+++ b/src/main/java/br/com/codenoir/domus/application/entity/UserEntity.java
@@ -19,7 +19,7 @@ public abstract class UserEntity {
     private UUID id;
 
     @Embedded
-    private Username userName;
+    private Username username;
 
     @Embedded
     private Password password;

--- a/src/main/java/br/com/codenoir/domus/application/repository/CompanyRepository.java
+++ b/src/main/java/br/com/codenoir/domus/application/repository/CompanyRepository.java
@@ -1,0 +1,8 @@
+package br.com.codenoir.domus.application.repository;
+
+import br.com.codenoir.domus.application.entity.CompanyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface CompanyRepository extends JpaRepository<CompanyEntity, UUID> {
+}

--- a/src/main/java/br/com/codenoir/domus/application/service/CompanyService.java
+++ b/src/main/java/br/com/codenoir/domus/application/service/CompanyService.java
@@ -1,0 +1,37 @@
+package br.com.codenoir.domus.application.service;
+
+import br.com.codenoir.domus.application.dto.CompanyRequestDTO;
+import br.com.codenoir.domus.application.entity.CompanyEntity;
+import br.com.codenoir.domus.application.repository.CompanyRepository;
+import br.com.codenoir.domus.application.security.BCryptPasswordEncoderService;
+import br.com.codenoir.domus.application.vo.CNPJ;
+import br.com.codenoir.domus.application.vo.EmailAddress;
+import br.com.codenoir.domus.application.vo.Password;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CompanyService {
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    public CompanyEntity create(CompanyRequestDTO companyRequest) {
+        var password = new BCryptPasswordEncoderService().encode(companyRequest.getPassword().getValue());
+        var company = new CompanyEntity();
+        company.setName(companyRequest.getName());
+        company.setUsername(companyRequest.getUsername());
+        company.setPassword(new Password(password));
+        company.setCnpj(new CNPJ(companyRequest.getCnpj().getValue()));
+        company.setEmailAddress(new EmailAddress(companyRequest.getEmailAddress().getValue()));
+
+        return this.companyRepository.save(company);
+    }
+
+    public List<CompanyEntity> findAll() {
+        return this.companyRepository.findAll();
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/vo/CNPJ.java
+++ b/src/main/java/br/com/codenoir/domus/application/vo/CNPJ.java
@@ -2,8 +2,7 @@ package br.com.codenoir.domus.application.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,8 +13,8 @@ public class CNPJ {
 
     @NotBlank(message = "CNPJ cannot blank")
     @NotNull(message = "CNPJ cannot null")
-    @org.hibernate.validator.constraints.br.CNPJ(message = "CNPJ is invalid")
     @Column(name = "cnpj")
+    @Size(min = 14, max = 14, message = "CNPJ must have exactly 14 numeric digits")
     private String value;
 
     public CNPJ(String value) {

--- a/src/main/java/br/com/codenoir/domus/application/vo/CPF.java
+++ b/src/main/java/br/com/codenoir/domus/application/vo/CPF.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,8 +15,8 @@ public class CPF {
 
     @NotBlank(message = "CPF cannot blank")
     @NotNull(message = "CPF cannot null")
-    @org.hibernate.validator.constraints.br.CPF(message = "CPF is invalid")
     @Column(name = "cpf")
+    @Size(min = 11, max = 11, message = "CPF must have exactly 11 numeric digits")
     private String value;
 
     public CPF(String value) {

--- a/src/main/java/br/com/codenoir/domus/application/vo/Password.java
+++ b/src/main/java/br/com/codenoir/domus/application/vo/Password.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,7 @@ public class Password {
 
     @NotBlank(message = "Password cannot blank")
     @NotNull(message = "Password cannot null")
-    @Min(value = 8, message = "Password must have at least 8 characters")
+    @Size(min = 8, message = "Password must have at least 8 characters")
     @Column(name = "password")
     private String value;
 

--- a/src/main/java/br/com/codenoir/domus/application/vo/Username.java
+++ b/src/main/java/br/com/codenoir/domus/application/vo/Username.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,7 @@ public class Username {
 
     @NotBlank(message = "Username cannot blank")
     @NotNull(message = "Username cannot null")
-    @Min(value = 6, message = "Username must have at least 6 characters")
+    @Size(min = 6, message = "Username must have at least 6 characters")
     @Column(name = "username")
     private String value;
 

--- a/src/main/java/br/com/codenoir/domus/gateway/DomusGatewayApplication.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/DomusGatewayApplication.java
@@ -2,8 +2,10 @@ package br.com.codenoir.domus.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = "br.com.codenoir.domus")
 public class DomusGatewayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/CompanyResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/CompanyResolver.java
@@ -1,0 +1,30 @@
+package br.com.codenoir.domus.gateway.controller;
+
+import br.com.codenoir.domus.application.dto.CompanyRequestDTO;
+import br.com.codenoir.domus.application.entity.CompanyEntity;
+import br.com.codenoir.domus.application.service.CompanyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+public class CompanyResolver {
+
+    @Autowired
+    private CompanyService companyService;
+
+    @MutationMapping
+    public CompanyEntity createCompany(@Argument("input") CompanyRequestDTO input) {
+        return companyService.create(input);
+    }
+
+    @QueryMapping
+    public List<CompanyEntity> companies() {
+        return companyService.findAll();
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/CompanyResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/CompanyResolver.java
@@ -3,6 +3,7 @@ package br.com.codenoir.domus.gateway.controller;
 import br.com.codenoir.domus.application.dto.CompanyRequestDTO;
 import br.com.codenoir.domus.application.entity.CompanyEntity;
 import br.com.codenoir.domus.application.service.CompanyService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
@@ -10,6 +11,8 @@ import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Controller
 public class CompanyResolver {
@@ -17,14 +20,29 @@ public class CompanyResolver {
     @Autowired
     private CompanyService companyService;
 
-    @MutationMapping
-    public CompanyEntity createCompany(@Argument("input") CompanyRequestDTO input) {
-        return companyService.create(input);
+    @QueryMapping
+    public Optional<CompanyEntity> getCompany(@Argument UUID id) {
+        return companyService.findById(id);
     }
 
     @QueryMapping
-    public List<CompanyEntity> companies() {
+    public List<CompanyEntity> getAllCompanies() {
         return companyService.findAll();
+    }
+
+    @MutationMapping
+    public CompanyEntity createCompany(@Argument @Valid CompanyRequestDTO input) {
+        return companyService.create(input);
+    }
+
+    @MutationMapping
+    public CompanyEntity updateCompany(@Argument UUID id, @Argument @Valid CompanyRequestDTO input) {
+        return companyService.update(id, input);
+    }
+
+    @MutationMapping
+    public Boolean deleteCompany(@Argument UUID id) {
+        return companyService.delete(id);
     }
 
 }

--- a/src/main/resources/graphql/mutation/company.graphqls
+++ b/src/main/resources/graphql/mutation/company.graphqls
@@ -1,0 +1,11 @@
+type Mutation {
+    createCompany(input: CreateCompanyInput!): Company!
+}
+
+input CreateCompanyInput {
+    name: String!
+    username: String!
+    password: String!
+    cnpj: String!
+    emailAddress: String!
+}

--- a/src/main/resources/graphql/mutation/company.graphqls
+++ b/src/main/resources/graphql/mutation/company.graphqls
@@ -1,11 +1,5 @@
 type Mutation {
-    createCompany(input: CreateCompanyInput!): Company!
-}
-
-input CreateCompanyInput {
-    name: String!
-    username: String!
-    password: String!
-    cnpj: String!
-    emailAddress: String!
+    createCompany(input: CompanyInput!): Company!
+    updateCompany(id: ID!, input: CompanyInput!): Company!
+    deleteCompany(id: ID!): Boolean!
 }

--- a/src/main/resources/graphql/query/company.graphqls
+++ b/src/main/resources/graphql/query/company.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    companies: [Company!]!
+}

--- a/src/main/resources/graphql/query/company.graphqls
+++ b/src/main/resources/graphql/query/company.graphqls
@@ -1,3 +1,4 @@
 type Query {
-    companies: [Company!]!
+    getAllCompanies: [Company!]!
+    getCompany(id: ID!): Company
 }

--- a/src/main/resources/graphql/types/company.graphqls
+++ b/src/main/resources/graphql/types/company.graphqls
@@ -4,5 +4,4 @@ type Company {
     name: String!
     emailAddress: String!
     username: String!
-    password: String!
 }

--- a/src/main/resources/graphql/types/company.graphqls
+++ b/src/main/resources/graphql/types/company.graphqls
@@ -1,0 +1,8 @@
+type Company {
+    id: ID!
+    cnpj: String!
+    name: String!
+    emailAddress: String!
+    username: String!
+    password: String!
+}

--- a/src/main/resources/graphql/types/companyInput.graphqls
+++ b/src/main/resources/graphql/types/companyInput.graphqls
@@ -1,0 +1,7 @@
+input CompanyInput {
+    name: String!
+    username: String!
+    password: String!
+    cnpj: String!
+    emailAddress: String!
+}


### PR DESCRIPTION
# Descrição

Este commit implementa as operações de criação e consulta da entidade Company utilizando GraphQL.
As funcionalidades incluem:
Mutation para criar uma nova Company
Query para buscar Company por ID, listar todas as Company, criar uma Company, alterar uma Company ou deletar uma Company.
Essa integração permite que clientes GraphQL interajam diretamente com os dados da entidade Company, aproveitando os benefícios de tipagem forte e consulta flexível.

# Tipo de Mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

# Checklist

- [x] Código segue o padrão de estilo do projeto.
- [ ] Foram adicionados testes para a nova funcionalidade ou correção.
- [ ] A documentação foi atualizada (se necessário).
- [ ] O SonarQube não reporta novos problemas críticos.
- [x] A aplicação foi testada localmente e está funcionando como esperado.