### PR TITLE
feat(employee): Implement employee creation with company membership and multiple roles

### DIFF
--- a/src/main/java/br/com/codenoir/domus/application/dto/EmployeeRequestDTO.java
+++ b/src/main/java/br/com/codenoir/domus/application/dto/EmployeeRequestDTO.java
@@ -1,0 +1,38 @@
+package br.com.codenoir.domus.application.dto;
+
+import br.com.codenoir.domus.application.enums.Roles;
+import br.com.codenoir.domus.application.vo.EmailAddress;
+import br.com.codenoir.domus.application.vo.Password;
+import br.com.codenoir.domus.application.vo.Username;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class EmployeeRequestDTO {
+
+    @Valid
+    private Username username;
+
+    @Valid
+    private Password password;
+
+    @NotBlank(message = "Name cannot blank")
+    private String firstName;
+
+    @NotBlank(message = "Last name cannot blank")
+    private String lastName;
+
+    @Valid
+    private EmailAddress emailAddress;
+
+    @NotBlank(message = "Company id cannot blank")
+    private String company_id;
+
+    @NotNull(message = "Roles cannot blank")
+    private List<@NotNull Roles> roles;
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/entity/EmployeeEntity.java
+++ b/src/main/java/br/com/codenoir/domus/application/entity/EmployeeEntity.java
@@ -1,10 +1,12 @@
 package br.com.codenoir.domus.application.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import br.com.codenoir.domus.application.enums.Roles;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Entity(name = "tb_employee")
@@ -12,9 +14,12 @@ import lombok.EqualsAndHashCode;
 public class EmployeeEntity extends UserEntity {
 
     @ManyToOne
-    @JoinColumn(name = "company_id", insertable=false, updatable=false)
-    private CompanyEntity companyId;
+    @JoinColumn(name = "company_id")
+    private CompanyEntity company;
 
-    private String roles;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "employee_roles", joinColumns = @JoinColumn(name = "employee_id"))
+    @Enumerated(EnumType.STRING)
+    private List<@NotNull Roles> roles;
 
 }

--- a/src/main/java/br/com/codenoir/domus/application/enums/Roles.java
+++ b/src/main/java/br/com/codenoir/domus/application/enums/Roles.java
@@ -1,0 +1,17 @@
+package br.com.codenoir.domus.application.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Roles {
+
+    ADMIN(0),
+    SURVEYOR(1);
+
+    private final int role;
+
+    Roles(int role) {
+        this.role = role;
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/repository/EmployeeRepository.java
+++ b/src/main/java/br/com/codenoir/domus/application/repository/EmployeeRepository.java
@@ -1,0 +1,9 @@
+package br.com.codenoir.domus.application.repository;
+
+import br.com.codenoir.domus.application.entity.EmployeeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EmployeeRepository extends JpaRepository <EmployeeEntity, UUID> {
+}

--- a/src/main/java/br/com/codenoir/domus/application/service/EmployeeService.java
+++ b/src/main/java/br/com/codenoir/domus/application/service/EmployeeService.java
@@ -1,0 +1,77 @@
+package br.com.codenoir.domus.application.service;
+
+import br.com.codenoir.domus.application.dto.EmployeeRequestDTO;
+import br.com.codenoir.domus.application.entity.EmployeeEntity;
+import br.com.codenoir.domus.application.repository.CompanyRepository;
+import br.com.codenoir.domus.application.repository.EmployeeRepository;
+import br.com.codenoir.domus.application.security.BCryptPasswordEncoderService;
+import br.com.codenoir.domus.application.vo.EmailAddress;
+import br.com.codenoir.domus.application.vo.Password;
+import br.com.codenoir.domus.application.vo.Username;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class EmployeeService {
+
+    @Autowired
+    EmployeeRepository employeeRepository;
+
+    @Autowired
+    CompanyRepository companyRepository;
+
+    @Autowired
+    BCryptPasswordEncoderService passwordEncoder;
+
+    public Optional<EmployeeEntity> findByIdEmployee(UUID id) {
+        return employeeRepository.findById(id);
+    }
+
+    public List<EmployeeEntity> findAllEmployees() {
+        return employeeRepository.findAll();
+    }
+
+    public EmployeeEntity create(EmployeeRequestDTO employeeRequest) {
+        var encodedPassword = passwordEncoder.encode(employeeRequest.getPassword().getValue());
+
+        var employee = new EmployeeEntity();
+
+        var company = companyRepository.findById(UUID.fromString(employeeRequest.getCompany_id()))
+                .orElseThrow(() -> new IllegalArgumentException("Company not found"));
+
+        employee.setUsername(new Username(employeeRequest.getUsername().getValue()));
+        employee.setPassword(new Password(encodedPassword));
+        employee.setFirstName(employeeRequest.getFirstName());
+        employee.setLastName(employeeRequest.getLastName());
+        employee.setEmailAddress(new EmailAddress(employeeRequest.getEmailAddress().getValue()));
+        employee.setCompany(company);
+        employee.setRoles(new ArrayList<>(employeeRequest.getRoles()));
+
+        return employeeRepository.save(employee);
+    }
+
+    public EmployeeEntity update(UUID id, EmployeeRequestDTO employeeRequest) {
+        return employeeRepository.findById(id).map(existingEmployee -> {
+            existingEmployee.setUsername(employeeRequest.getUsername());
+            existingEmployee.setFirstName(employeeRequest.getFirstName());
+            existingEmployee.setLastName(employeeRequest.getLastName());
+            existingEmployee.setEmailAddress(new EmailAddress(employeeRequest.getEmailAddress().getValue()));
+            existingEmployee.setRoles(new ArrayList<>(employeeRequest.getRoles()));
+            return employeeRepository.save(existingEmployee);
+        }).orElseThrow(() -> new IllegalArgumentException("Employee not found with id: " + id));
+    }
+
+    public Boolean delete(UUID id) {
+        if(employeeRepository.existsById(id)) {
+            employeeRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/EmployeeResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/EmployeeResolver.java
@@ -1,0 +1,48 @@
+package br.com.codenoir.domus.gateway.controller;
+
+import br.com.codenoir.domus.application.dto.EmployeeRequestDTO;
+import br.com.codenoir.domus.application.entity.EmployeeEntity;
+import br.com.codenoir.domus.application.service.EmployeeService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Controller
+public class EmployeeResolver {
+
+    @Autowired
+    EmployeeService employeeService;
+
+    @QueryMapping
+    public Optional<EmployeeEntity> getEmployee(@Argument UUID id) {
+        return employeeService.findByIdEmployee(id);
+    }
+
+    @QueryMapping
+    public List<EmployeeEntity> getAllEmployees() {
+        return employeeService.findAllEmployees();
+    }
+
+    @MutationMapping
+    public EmployeeEntity createEmployee(@Argument @Valid EmployeeRequestDTO input) {
+        return employeeService.create(input);
+    }
+
+    @MutationMapping
+    public EmployeeEntity updateEmployee(@Argument UUID id, @Argument @Valid EmployeeRequestDTO input) {
+        return employeeService.update(id, input);
+    }
+
+    @MutationMapping
+    public Boolean deleteEmployee(@Argument UUID id) {
+        return employeeService.delete(id);
+    }
+
+}

--- a/src/main/resources/graphql/mutation/company.graphqls
+++ b/src/main/resources/graphql/mutation/company.graphqls
@@ -2,4 +2,7 @@ type Mutation {
     createCompany(input: CompanyInput!): Company!
     updateCompany(id: ID!, input: CompanyInput!): Company!
     deleteCompany(id: ID!): Boolean!
+    createEmployee(input: EmployeeInput!): Employee
+    updateEmployee(id: ID!, input: EmployeeInput!): Employee!
+    deleteEmployee(id: ID!): Boolean!
 }

--- a/src/main/resources/graphql/query/company.graphqls
+++ b/src/main/resources/graphql/query/company.graphqls
@@ -1,4 +1,6 @@
 type Query {
     getAllCompanies: [Company!]!
     getCompany(id: ID!): Company
+    getEmployee(id: ID!): Employee
+    getAllEmployees: [Employee!]!
 }

--- a/src/main/resources/graphql/types/employee.graphqls
+++ b/src/main/resources/graphql/types/employee.graphqls
@@ -1,0 +1,9 @@
+type Employee {
+    id: ID!
+    username: String!
+    firstName: String!
+    lastName: String!
+    emailAddress: String!
+    company_id: String!
+    roles: [String!]!
+}

--- a/src/main/resources/graphql/types/employeeInput.graphqls
+++ b/src/main/resources/graphql/types/employeeInput.graphqls
@@ -1,0 +1,9 @@
+input EmployeeInput {
+    username: String!
+    password: String!
+    firstName: String!
+    lastName: String!
+    emailAddress: String!
+    company_id: String!
+    roles: [String!]!
+}


### PR DESCRIPTION
# Descrição

Esta PR adiciona a funcionalidade de criação de um employee, incluindo associação a uma company existente e definição de múltiplos roles.
As principais alterações foram:
•	Criação do resolver createEmployee na API GraphQL.
•	Implementação do mapeamento dos roles como lista de enum.

# Tipo de Mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

# Checklist

- [x] Código segue o padrão de estilo do projeto.
- [ ] Foram adicionados testes para a nova funcionalidade ou correção.
- [ ] A documentação foi atualizada (se necessário).
- [ ] O SonarQube não reporta novos problemas críticos.
- [x] A aplicação foi testada localmente e está funcionando como esperado.