### PR TITLE
feat(offerProperty): Creation of the OfferProperty functionality with OfferType support

### DIFF
--- a/src/main/java/br/com/codenoir/domus/application/dto/OfferPropertyRequestDTO.java
+++ b/src/main/java/br/com/codenoir/domus/application/dto/OfferPropertyRequestDTO.java
@@ -1,0 +1,24 @@
+package br.com.codenoir.domus.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class OfferPropertyRequestDTO {
+
+    private LocalDateTime date;
+
+    @NotNull(message = "Type Offer should not be null")
+    private int offerType;
+
+    @NotNull(message = "Property id should not be null")
+    private String property_id;
+
+    @Size(min = 1, message = "Price should not be less than 1 (one).")
+    private BigDecimal price;
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/entity/OfferPropertyEntity.java
+++ b/src/main/java/br/com/codenoir/domus/application/entity/OfferPropertyEntity.java
@@ -1,9 +1,9 @@
 package br.com.codenoir.domus.application.entity;
 
+import br.com.codenoir.domus.application.enums.OfferType;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -22,15 +22,14 @@ public class OfferPropertyEntity {
     @CreationTimestamp
     private LocalDateTime date;
 
-    @NotBlank(message = "Type Offer should not be blank")
-    @NotNull
-    private String typeOffer;
+    @NotNull(message = "Type Offer should not be null")
+    private OfferType offerType;
 
     @OneToOne()
     @JoinColumn(name = "property_id", insertable=false, updatable=false)
     private PropertyEntity propertyId;
 
-    @Min(value = 1, message = "Price should not be less than 1 (one).")
+    @Size(min = 1, message = "Price should not be less than 1 (one).")
     private BigDecimal price;
 
 }

--- a/src/main/java/br/com/codenoir/domus/application/enums/OfferType.java
+++ b/src/main/java/br/com/codenoir/domus/application/enums/OfferType.java
@@ -1,0 +1,28 @@
+package br.com.codenoir.domus.application.enums;
+
+public enum OfferType {
+
+    SALE(0),
+    RENT(1);
+
+    private final int offerType;
+
+    OfferType(int offerType) {
+        this.offerType = offerType;
+    }
+
+    public int getCode() {
+        return offerType;
+    }
+
+    public static OfferType fromCode(int code) {
+        for(OfferType type : OfferType.values()) {
+            if(type.getCode() == code) {
+                return type;
+            }
+        }
+
+        throw new IllegalArgumentException("Code invalid for OfferType: " + code);
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/repository/OfferPropertyRepository.java
+++ b/src/main/java/br/com/codenoir/domus/application/repository/OfferPropertyRepository.java
@@ -1,0 +1,9 @@
+package br.com.codenoir.domus.application.repository;
+
+import br.com.codenoir.domus.application.entity.OfferPropertyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OfferPropertyRepository extends JpaRepository<OfferPropertyEntity, UUID> {
+}

--- a/src/main/java/br/com/codenoir/domus/application/service/OfferPropertyService.java
+++ b/src/main/java/br/com/codenoir/domus/application/service/OfferPropertyService.java
@@ -1,0 +1,66 @@
+package br.com.codenoir.domus.application.service;
+
+import br.com.codenoir.domus.application.dto.OfferPropertyRequestDTO;
+import br.com.codenoir.domus.application.entity.OfferPropertyEntity;
+import br.com.codenoir.domus.application.enums.OfferType;
+import br.com.codenoir.domus.application.repository.OfferPropertyRepository;
+import br.com.codenoir.domus.application.repository.PropertyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class OfferPropertyService {
+
+    @Autowired
+    OfferPropertyRepository offerPropertyRepository;
+
+    @Autowired
+    PropertyRepository propertyRepository;
+
+    public Optional<OfferPropertyEntity> findById(UUID id) {
+        return offerPropertyRepository.findById(id);
+    }
+
+    public List<OfferPropertyEntity> findAll() {
+        return offerPropertyRepository.findAll();
+    }
+
+    public OfferPropertyEntity create(OfferPropertyRequestDTO offerPropertyRequestDTO) {
+        var property = propertyRepository.findById(UUID.fromString(offerPropertyRequestDTO.getProperty_id()))
+            .orElseThrow(() -> new IllegalArgumentException("Property not found"));
+
+        var offerProperty = new OfferPropertyEntity();
+
+        offerProperty.setOfferType(OfferType.fromCode(offerPropertyRequestDTO.getOfferType()));
+        offerProperty.setPropertyId(property);
+        offerProperty.setPrice(new BigDecimal(String.valueOf(offerPropertyRequestDTO.getPrice())));
+
+        return offerPropertyRepository.save(offerProperty);
+    }
+
+    public OfferPropertyEntity update(UUID id, OfferPropertyRequestDTO offerPropertyRequestDTO) {
+        var property = propertyRepository.findById(UUID.fromString(offerPropertyRequestDTO.getProperty_id()))
+            .orElseThrow(() -> new IllegalArgumentException("Property not found"));
+
+        return offerPropertyRepository.findById(id).map(existingOfferProperty -> {
+            existingOfferProperty.setOfferType(OfferType.fromCode(offerPropertyRequestDTO.getOfferType()));
+            existingOfferProperty.setPropertyId(property);
+            existingOfferProperty.setPrice(new BigDecimal(String.valueOf(offerPropertyRequestDTO.getPrice())));
+            return offerPropertyRepository.save(existingOfferProperty);
+        }).orElseThrow(() -> new IllegalArgumentException("Offer property not found with id: " + id));
+    }
+
+    public boolean delete(UUID id) {
+        if(offerPropertyRepository.existsById(id)) {
+            offerPropertyRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/OfferPropertyResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/OfferPropertyResolver.java
@@ -1,0 +1,48 @@
+package br.com.codenoir.domus.gateway.controller;
+
+import br.com.codenoir.domus.application.dto.OfferPropertyRequestDTO;
+import br.com.codenoir.domus.application.entity.OfferPropertyEntity;
+import br.com.codenoir.domus.application.service.OfferPropertyService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Controller
+public class OfferPropertyResolver {
+
+    @Autowired
+    OfferPropertyService offerPropertyService;
+
+    @QueryMapping
+    public Optional<OfferPropertyEntity> getOfferProperty(@Argument UUID id) {
+        return offerPropertyService.findById(id);
+    }
+
+    @QueryMapping
+    public List<OfferPropertyEntity> getAllOfferProperties() {
+        return offerPropertyService.findAll();
+    }
+
+    @MutationMapping
+    public OfferPropertyEntity createOfferProperty(@Argument @Valid OfferPropertyRequestDTO offerPropertyRequestDTO) {
+        return offerPropertyService.create(offerPropertyRequestDTO);
+    }
+
+    @MutationMapping
+    public OfferPropertyEntity updateOfferProperty(@Argument UUID id, @Argument @Valid OfferPropertyRequestDTO offerPropertyRequestDTO) {
+        return offerPropertyService.update(id, offerPropertyRequestDTO);
+    }
+
+    @MutationMapping
+    public boolean deleteOfferProperty(@Argument UUID id) {
+        return offerPropertyService.delete(id);
+    }
+
+}

--- a/src/main/resources/graphql/types/offerProperty.graphqls
+++ b/src/main/resources/graphql/types/offerProperty.graphqls
@@ -1,0 +1,7 @@
+type OfferProperty {
+    id: ID!
+    date: String
+    offerType: Int!
+    property_id: String!
+    price: String!
+}

--- a/src/main/resources/graphql/types/offerPropertyInput.graphqls
+++ b/src/main/resources/graphql/types/offerPropertyInput.graphqls
@@ -1,0 +1,5 @@
+input OfferPropertyInput {
+    offerType: Int!
+    property_id: String!
+    price: String!
+}


### PR DESCRIPTION
# Descrição

Esta PR implementa a funcionalidade de criação de OfferProperty no sistema, permitindo associar uma propriedade a uma oferta de venda ou aluguel.

Alterações incluídas:
- Criação do enum OfferType (SELL, RENT) com mapeamento de código inteiro.
- Criação do DTO OfferPropertyInput para entrada de dados via GraphQL.
- Implementação do OfferPropertyEntity e OfferPropertyRepository.
- Implementação do OfferPropertyService com lógica de criação e validação.
- Implementação do OfferPropertyResolver para exposição via GraphQL.
- Conversão de inteiro para enum no fluxo de criação de OfferProperty.

Com esta funcionalidade, é possível criar ofertas de propriedades indicando o tipo de oferta (venda ou aluguel) utilizando o código 0 (SELL) ou 1 (RENT).

# Tipo de Mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

# Checklist

- [x] Código segue o padrão de estilo do projeto.
- [ ] Foram adicionados testes para a nova funcionalidade ou correção.
- [ ] A documentação foi atualizada (se necessário).
- [ ] O SonarQube não reporta novos problemas críticos.
- [x] A aplicação foi testada localmente e está funcionando como esperado.