### PR TITLE
feat(owner): implements CRUD mutations for Owner entity with enum OwnerType

### DIFF
--- a/src/main/java/br/com/codenoir/domus/application/dto/OwnerRequestDTO.java
+++ b/src/main/java/br/com/codenoir/domus/application/dto/OwnerRequestDTO.java
@@ -1,0 +1,36 @@
+package br.com.codenoir.domus.application.dto;
+
+import br.com.codenoir.domus.application.enums.OwnerType;
+import br.com.codenoir.domus.application.vo.*;
+import jakarta.persistence.Embedded;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.Data;
+
+@Data
+public class OwnerRequestDTO {
+
+    @Valid
+    private Username username;
+
+    @Valid
+    private Password password;
+
+    @NotNull(message = "First name cannot null")
+    private String firstName;
+
+    @NotNull(message = "Last name cannot null")
+    private String lastName;
+
+    @Valid
+    private EmailAddress emailAddress;
+
+    @NotNull(message = "Owner type should not be null")
+    private Integer ownerType;
+
+    @NotNull(message = "Document should not be null")
+    private String document;
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/entity/OwnerEntity.java
+++ b/src/main/java/br/com/codenoir/domus/application/entity/OwnerEntity.java
@@ -1,8 +1,13 @@
 package br.com.codenoir.domus.application.entity;
 
+import br.com.codenoir.domus.application.enums.OwnerType;
+import br.com.codenoir.domus.application.vo.CNPJ;
 import br.com.codenoir.domus.application.vo.CPF;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -11,9 +16,14 @@ import lombok.EqualsAndHashCode;
 @Data
 public class OwnerEntity extends UserEntity {
 
-    private String ownerType;
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "Owner type should not be null")
+    private OwnerType ownerType;
 
     @Embedded
     private CPF cpf;
+
+    @Embedded
+    private CNPJ cnpj;
 
 }

--- a/src/main/java/br/com/codenoir/domus/application/enums/OwnerType.java
+++ b/src/main/java/br/com/codenoir/domus/application/enums/OwnerType.java
@@ -1,0 +1,28 @@
+package br.com.codenoir.domus.application.enums;
+
+public enum OwnerType {
+
+    INDIVIDUAL(0),
+    LEGAL_ENTITY(1);
+
+    private final int ownerType;
+
+    OwnerType(int ownerType) {
+        this.ownerType = ownerType;
+    }
+
+    public int getOwnerType() {
+        return ownerType;
+    }
+
+    public static OwnerType fromCode(int ownerType) {
+        for(OwnerType type : OwnerType.values()) {
+            if(type.getOwnerType() == ownerType) {
+                return type;
+            }
+        }
+
+        throw new IllegalArgumentException("Owner type invalid: " + ownerType);
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/application/repository/OwnerRepository.java
+++ b/src/main/java/br/com/codenoir/domus/application/repository/OwnerRepository.java
@@ -1,0 +1,9 @@
+package br.com.codenoir.domus.application.repository;
+
+import br.com.codenoir.domus.application.entity.OwnerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OwnerRepository extends JpaRepository<OwnerEntity, UUID> {
+}

--- a/src/main/java/br/com/codenoir/domus/application/service/OwnerService.java
+++ b/src/main/java/br/com/codenoir/domus/application/service/OwnerService.java
@@ -1,0 +1,81 @@
+package br.com.codenoir.domus.application.service;
+
+import br.com.codenoir.domus.application.dto.OwnerRequestDTO;
+import br.com.codenoir.domus.application.entity.OwnerEntity;
+import br.com.codenoir.domus.application.enums.OwnerType;
+import br.com.codenoir.domus.application.repository.OwnerRepository;
+import br.com.codenoir.domus.application.security.BCryptPasswordEncoderService;
+import br.com.codenoir.domus.application.vo.CNPJ;
+import br.com.codenoir.domus.application.vo.CPF;
+import br.com.codenoir.domus.application.vo.EmailAddress;
+import br.com.codenoir.domus.application.vo.Password;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class OwnerService {
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    @Autowired
+    BCryptPasswordEncoderService passwordEncoderService;
+
+    public Optional<OwnerEntity> findById(UUID id) {
+        return ownerRepository.findById(id);
+    }
+
+    public List<OwnerEntity> findAll() {
+        return ownerRepository.findAll();
+    }
+
+    public OwnerEntity create(OwnerRequestDTO ownerRequestDTO) {
+        var encodedPassword = passwordEncoderService.encode(ownerRequestDTO.getPassword().getValue());
+        var owner = new OwnerEntity();
+        var ownerType = OwnerType.fromCode(ownerRequestDTO.getOwnerType());
+
+
+        owner.setUsername(ownerRequestDTO.getUsername());
+        owner.setPassword(new Password(encodedPassword));
+        owner.setEmailAddress(new EmailAddress(ownerRequestDTO.getEmailAddress().getValue()));
+        owner.setFirstName(ownerRequestDTO.getFirstName());
+        owner.setLastName(ownerRequestDTO.getLastName());
+        owner.setOwnerType(ownerType);
+
+        switch (ownerType) {
+            case LEGAL_ENTITY -> owner.setCnpj(new CNPJ(ownerRequestDTO.getDocument()));
+            case INDIVIDUAL -> owner.setCpf(new CPF(ownerRequestDTO.getDocument()));
+        }
+
+        return ownerRepository.save(owner);
+    }
+
+    public OwnerEntity update(UUID id, OwnerRequestDTO ownerRequestDTO) {
+        var ownerType = OwnerType.fromCode(ownerRequestDTO.getOwnerType());
+        return ownerRepository.findById(id).map(existingOwner -> {
+            existingOwner.setUsername(ownerRequestDTO.getUsername());
+            existingOwner.setEmailAddress(new EmailAddress(ownerRequestDTO.getEmailAddress().getValue()));
+            existingOwner.setFirstName(ownerRequestDTO.getFirstName());
+            existingOwner.setLastName(ownerRequestDTO.getLastName());
+            existingOwner.setOwnerType(ownerType);
+            switch (ownerType) {
+                case LEGAL_ENTITY -> existingOwner.setCnpj(new CNPJ(ownerRequestDTO.getDocument()));
+                case INDIVIDUAL -> existingOwner.setCpf(new CPF(ownerRequestDTO.getDocument()));
+            }
+            return ownerRepository.save(existingOwner);
+        }).orElseThrow(() -> new IllegalArgumentException("Owner not found"));
+    }
+
+    public boolean delete(UUID id) {
+        if(ownerRepository.existsById(id)) {
+            ownerRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/OfferPropertyResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/OfferPropertyResolver.java
@@ -31,13 +31,13 @@ public class OfferPropertyResolver {
     }
 
     @MutationMapping
-    public OfferPropertyEntity createOfferProperty(@Argument @Valid OfferPropertyRequestDTO offerPropertyRequestDTO) {
-        return offerPropertyService.create(offerPropertyRequestDTO);
+    public OfferPropertyEntity createOfferProperty(@Argument @Valid OfferPropertyRequestDTO input) {
+        return offerPropertyService.create(input);
     }
 
     @MutationMapping
-    public OfferPropertyEntity updateOfferProperty(@Argument UUID id, @Argument @Valid OfferPropertyRequestDTO offerPropertyRequestDTO) {
-        return offerPropertyService.update(id, offerPropertyRequestDTO);
+    public OfferPropertyEntity updateOfferProperty(@Argument UUID id, @Argument @Valid OfferPropertyRequestDTO input) {
+        return offerPropertyService.update(id, input);
     }
 
     @MutationMapping

--- a/src/main/java/br/com/codenoir/domus/gateway/controller/OwnerResolver.java
+++ b/src/main/java/br/com/codenoir/domus/gateway/controller/OwnerResolver.java
@@ -1,0 +1,50 @@
+package br.com.codenoir.domus.gateway.controller;
+
+import br.com.codenoir.domus.application.dto.OwnerRequestDTO;
+import br.com.codenoir.domus.application.entity.OwnerEntity;
+import br.com.codenoir.domus.application.service.OwnerService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Controller
+public class OwnerResolver {
+
+    @Autowired
+    OwnerService ownerService;
+
+    @QueryMapping
+    public Optional<OwnerEntity> getOwner(@Argument UUID id) {
+        return ownerService.findById(id);
+    }
+
+    @QueryMapping
+    public List<OwnerEntity> getAllOwners() {
+        return ownerService.findAll();
+    }
+
+    @MutationMapping
+    public OwnerEntity createOwner(@Argument OwnerRequestDTO input) {
+        System.out.println("Dados da requisiçao:");
+        System.out.println(input.getOwnerType());
+        return ownerService.create(input);
+    }
+
+    @MutationMapping
+    public OwnerEntity updateOwner(@Argument UUID id, @Argument OwnerRequestDTO input) {
+        return ownerService.update(id, input);
+    }
+
+    @MutationMapping
+    public boolean deleteOwner(@Argument UUID id) {
+        return ownerService.delete(id);
+    }
+
+}

--- a/src/main/resources/graphql/mutation/company.graphqls
+++ b/src/main/resources/graphql/mutation/company.graphqls
@@ -1,8 +1,0 @@
-type Mutation {
-    createCompany(input: CompanyInput!): Company!
-    updateCompany(id: ID!, input: CompanyInput!): Company!
-    deleteCompany(id: ID!): Boolean!
-    createEmployee(input: EmployeeInput!): Employee
-    updateEmployee(id: ID!, input: EmployeeInput!): Employee!
-    deleteEmployee(id: ID!): Boolean!
-}

--- a/src/main/resources/graphql/mutation/mutations.graphqls
+++ b/src/main/resources/graphql/mutation/mutations.graphqls
@@ -1,0 +1,17 @@
+type Mutation {
+    createCompany(input: CompanyInput!): Company!
+    updateCompany(id: ID!, input: CompanyInput!): Company!
+    deleteCompany(id: ID!): Boolean!
+
+    createEmployee(input: EmployeeInput!): Employee!
+    updateEmployee(id: ID!, input: EmployeeInput!): Employee!
+    deleteEmployee(id: ID!): Boolean!
+
+    createOfferProperty(input: OfferPropertyInput!): OfferProperty!
+    updateOfferProperty(id: ID!, input: OfferPropertyInput!): OfferProperty!
+    deleteOfferProperty(id: ID!): Boolean!
+
+    createOwner(input: OwnerInput!): Owner!
+    updateOwner(id: ID!, input: OwnerInput!): Owner!
+    deleteOwner(id: ID!): Boolean!
+}

--- a/src/main/resources/graphql/query/company.graphqls
+++ b/src/main/resources/graphql/query/company.graphqls
@@ -1,6 +1,0 @@
-type Query {
-    getAllCompanies: [Company!]!
-    getCompany(id: ID!): Company
-    getEmployee(id: ID!): Employee
-    getAllEmployees: [Employee!]!
-}

--- a/src/main/resources/graphql/query/queries.graphqls
+++ b/src/main/resources/graphql/query/queries.graphqls
@@ -1,0 +1,13 @@
+type Query {
+    getCompany(id: ID!): Company
+    getAllCompanies: [Company!]!
+
+    getEmployee(id: ID!): Employee
+    getAllEmployees: [Employee!]!
+
+    getOfferProperty(id: ID!): OfferProperty
+    getAllOfferProperties: [OfferProperty!]!
+
+    getOwner(id: ID!): Owner
+    getAllOwners: [Owner!]!
+}

--- a/src/main/resources/graphql/types/owner.graphqls
+++ b/src/main/resources/graphql/types/owner.graphqls
@@ -1,0 +1,14 @@
+enum OwnerType {
+    INDIVIDUAL
+    LEGAL_ENTITY
+}
+
+type Owner {
+    id: ID!
+    username: String!
+    firstName: String!
+    lastName: String!
+    emailAddress: String!
+    ownerType: OwnerType!
+    document: String!
+}

--- a/src/main/resources/graphql/types/ownerInput.graphqls
+++ b/src/main/resources/graphql/types/ownerInput.graphqls
@@ -1,0 +1,9 @@
+input OwnerInput {
+    username: String!
+    password: String!
+    firstName: String!
+    lastName: String!
+    emailAddress: String!
+    ownerType: Int!
+    document: String!
+}


### PR DESCRIPTION
# Descrição

Esta PR adiciona as operações de CRUD da entidade Owner na API GraphQL, incluindo:

- Criação das mutations `createOwner`, `updateOwner` e `deleteOwner`
- Definição do enum `OwnerType` no schema GraphQL e no backend Java
- Mapeamento de entrada e saída entre o DTO `OwnerRequestDTO` e a entidade `OwnerEntity`
- Validação de dados e tratamento de tipos no GraphQL

# Tipo de Mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

# Checklist

- [x] Código segue o padrão de estilo do projeto.
- [ ] Foram adicionados testes para a nova funcionalidade ou correção.
- [ ] A documentação foi atualizada (se necessário).
- [ ] O SonarQube não reporta novos problemas críticos.
- [x] A aplicação foi testada localmente e está funcionando como esperado.